### PR TITLE
Added a new test to validate the ccss generation when mixing variable gap and gap functions in a VFL expression.

### DIFF
--- a/spec/compiler.coffee
+++ b/spec/compiler.coffee
@@ -368,6 +368,16 @@ describe 'VFL-to-CCSS Compiler', ->
             '#b2[right] + [my-outer-gap] == #parent[right]'
           ]
 
+    parse """
+            @h |-[my-outer-gap]-(#b1)-(#b2)-[my-outer-gap]-| in(#parent) gap([my-gap]); // mixed var gaps with function gap            
+          """
+        ,
+          [
+            '#parent[left] + [my-outer-gap] == #b1[left]'
+            '#b1[right] + [my-gap] == #b2[left]'
+            '#b2[right] + [my-outer-gap] == #parent[right]'
+          ]
+
     expectError '@h |-(#box]-;'
 
   # Points

--- a/spec/compiler.coffee
+++ b/spec/compiler.coffee
@@ -358,12 +358,17 @@ describe 'VFL-to-CCSS Compiler', ->
             '#sub2[right] + [baseline] == #parent[right]'
           ]
 
+    parse """
+            @h |-(#b1)-[my-gap]-(#b2)-| in(#parent) outer-gap([my-outer-gap]); // mixed var gaps with function gap            
+          """
+        ,
+          [
+            '#parent[left] + [my-outer-gap] == #b1[left]'
+            '#b1[right] + [my-gap] == #b2[left]'
+            '#b2[right] + [my-outer-gap] == #parent[right]'
+          ]
+
     expectError '@h |-(#box]-;'
-
-
-
-
-
 
   # Points
   # --------------------------------------------------


### PR DESCRIPTION
When mixing variable gap with gap function, the generated CCSS is invalid. See http://codepen.io/cbchouinard/pen/azWKoq for an example. 
